### PR TITLE
Integrate DOM and Gtk allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ you used as the widget's name.
 <canvas class="GtkWidget" id="myentry"></canvas>
 ```
 
+Maxwell will also try to honor width and height style properties set on the
+canvas element.
+So for example if you want your widget to expand horizontally you can do:
+```html
+<canvas class="GtkWidget" style="width: 100%;" id="myentry"></canvas>
+```
+
 ## Building
  * Install [meson] and [ninja]
  * `$ sudo apt-get install meson`

--- a/examples/maxwell-test.c
+++ b/examples/maxwell-test.c
@@ -79,7 +79,7 @@ main (int argc, char *argv[])
                              "  <h1>MaxwellWebview Test</h1>"
                              "Lorem ipsum dolor sit amet, consectetur adipiscing elit,<br>"
                              "  <h2>A GtkButton</h2>"
-                             "   <canvas class=\"GtkWidget\" id=\"box\"></canvas>"
+                             "   <canvas class=\"GtkWidget\" id=\"box\" style=\"width: 100%;\"></canvas>"
                              "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br>"
                              "  <h2>A HTML text input</h2>"
                              "  <input type=\"text\">"

--- a/src/js-utils.c
+++ b/src/js-utils.c
@@ -33,13 +33,18 @@ _js_run_finish_handler (GObject *object, GAsyncResult *result, gpointer data)
 
   js_result = webkit_web_view_run_javascript_finish (WEBKIT_WEB_VIEW (object),
                                                      result, &error);
-  if (!js_result)
+  if (js_result)
     {
-      g_warning ("JS Error in %s(): %s", function, error->message);
+      webkit_javascript_result_unref (js_result);
+    }
+  else
+    {
+      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_warning ("JS Error in %s(): %s", function, error->message);
+
       g_error_free (error);
     }
 
-  webkit_javascript_result_unref (js_result);
   g_free (function);
 }
 

--- a/src/js-utils.c
+++ b/src/js-utils.c
@@ -45,6 +45,7 @@ _js_run_finish_handler (GObject *object, GAsyncResult *result, gpointer data)
 
 void
 _js_run_printf (WebKitWebView *webview,
+                GCancellable  *cancellable,
                 const gchar   *function,
                 const gchar   *format,
                 ...)
@@ -57,18 +58,23 @@ _js_run_printf (WebKitWebView *webview,
   va_end (args);
 
   webkit_web_view_run_javascript (WEBKIT_WEB_VIEW (webview),
-                                  script, NULL,
+                                  script,
+                                  cancellable,
                                   _js_run_finish_handler,
                                   g_strdup (function));
   g_free (script);
 }
 
 void
-_js_run_string (WebKitWebView *webview, const gchar *function, GString *script)
+_js_run_string (WebKitWebView *webview,
+                GCancellable  *cancellable,
+                const gchar   *function,
+                GString       *script)
 {
   if (script && script->len)
     webkit_web_view_run_javascript (WEBKIT_WEB_VIEW (webview),
-                                    script->str, NULL,
+                                    script->str,
+                                    cancellable,
                                     _js_run_finish_handler,
                                     g_strdup (function));
 }

--- a/src/js-utils.h
+++ b/src/js-utils.h
@@ -31,14 +31,16 @@
 #include <JavaScriptCore/JSStringRef.h>
 
 G_BEGIN_DECLS
-#define js_run_string(w,s) _js_run_string (WEBKIT_WEB_VIEW (w), __func__, s)
-#define js_run_printf(w,f,...) _js_run_printf (WEBKIT_WEB_VIEW (w), __func__, f, __VA_ARGS__)
+#define js_run_string(w,c,s) _js_run_string (WEBKIT_WEB_VIEW (w), c, __func__, s)
+#define js_run_printf(w,c,f,...) _js_run_printf (WEBKIT_WEB_VIEW (w), c, __func__, f, __VA_ARGS__)
 
 void        _js_run_string         (WebKitWebView *webview,
+                                    GCancellable  *cancellable,
                                     const gchar   *function,
                                     GString       *script);
 
 void        _js_run_printf         (WebKitWebView *webview,
+                                    GCancellable  *cancellable,
                                     const gchar   *function,
                                     const gchar   *format,
                                     ...);

--- a/src/maxwell-web-view.js
+++ b/src/maxwell-web-view.js
@@ -215,7 +215,4 @@ window.maxwell.child_set_visible = function (id, visible) {
         child.style.display = (visible) ? child.maxwell_display_value : 'none';
 }
 
-/* Signal MaxwellWebView the script has finished loading */
-window.webkit.messageHandlers.maxwell_script_loaded.postMessage({});
-
 })();


### PR DESCRIPTION
Use CSS width/height if set or Gtk natural size otherwise.
Also min-width and min-height will be set to match Gtk minimum size.

This allows, for example, setting 'width: 100%;' on a Widget element

https://phabricator.endlessm.com/T21356